### PR TITLE
Add Tab UI

### DIFF
--- a/app/categories/[categoryId]/page.tsx
+++ b/app/categories/[categoryId]/page.tsx
@@ -1,14 +1,15 @@
 import Header from "@/components/Header";
 import ThreadCategoryTab from "@/components/ThreadCategoryTab";
 import ThreadList from "@/components/ThreadList";
-import { defaultCategory } from "@/model/Category";
 import { Suspense } from "react";
 
-export default function Index() {
+export default function Index({ params }: {
+  params: { categoryId: string },
+}) {
   return (
     <div className="max-w-screen-lg mx-auto">
       <Header />
-      <ThreadCategoryTab currentCategoryId={defaultCategory.id} />
+      <ThreadCategoryTab currentCategoryId={params.categoryId} />
       <div>
         <Suspense fallback={<div>取得中...</div>}>
           <ThreadList categoryId={"categoryId"} />

--- a/app/categories/[categoryId]/page.tsx
+++ b/app/categories/[categoryId]/page.tsx
@@ -1,11 +1,17 @@
 import Header from "@/components/Header";
 import ThreadCategoryTab from "@/components/ThreadCategoryTab";
 import ThreadList from "@/components/ThreadList";
+import { categories } from "@/model/Category";
+import { notFound } from 'next/navigation';
 import { Suspense } from "react";
 
 export default function Index({ params }: {
   params: { categoryId: string },
 }) {
+  if (!categories.some((category) => category.id === params.categoryId)) {
+    notFound()
+  }
+
   return (
     <div className="max-w-screen-lg mx-auto">
       <Header />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Header from "@/components/Header";
+import ThreadCategoryTab from "@/components/ThreadCategoryTab";
 import ThreadList from "@/components/ThreadList";
 import { Suspense } from "react";
 
@@ -6,6 +7,7 @@ export default function Index() {
   return (
     <div className="max-w-screen-lg mx-auto">
       <Header />
+      <ThreadCategoryTab currentCategoryId="hot" />
       <div>
         <Suspense fallback={<div>取得中...</div>}>
           <ThreadList categoryId={"categoryId"} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,5 @@
 import { Kaisei_Opti } from 'next/font/google';
+import Link from 'next/link';
 
 const HeaderText = Kaisei_Opti({
     weight: "400",
@@ -8,7 +9,9 @@ const HeaderText = Kaisei_Opti({
 export default function Header() {
     return (
         <div className="w-full h-20 flex items-center px-4">
-            <h1 className={`${HeaderText.className} text-3xl`}>れんしゅうけいじばん</h1>
+            <Link href="/">
+                <h1 className={`${HeaderText.className} text-3xl`}>れんしゅうけいじばん</h1>
+            </Link>
         </div>
     )
 }

--- a/components/ThreadCategoryTab.tsx
+++ b/components/ThreadCategoryTab.tsx
@@ -1,30 +1,22 @@
-type Category = {
-    id: string
-    text: string
-}
-
-const categories = [
-    { id: "hot", text: "注目" },
-    { id: "chat", text: "雑談" },
-    { id: "social", text: "世の中" },
-    { id: "life", text: "生活" },
-    { id: "game", text: "アニメ・ゲーム" },
-    { id: "entertainment", text: "エンタメ" },
-    { id: "it", text: "テクノロジー" }
-]
+import { Category, categories, defaultCategory } from "@/model/Category";
+import Link from "next/link";
 
 export default function ThreadCategoryTab({ currentCategoryId }: { currentCategoryId: string }) {
+    if (!categories.some((category) => category.id === currentCategoryId)) {
+        currentCategoryId = defaultCategory.id
+    }
+
     return (
         <div className="text-sm font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700">
             <ul className="flex flex-wrap -mb-px">
                 {categories.map((category: Category) => {
                     return (
                         <li key={category.id} className="mr-2">
-                            <a href="#" className={`inline-block p-4 border-b-2 rounded-t-lg
+                            <Link href={"/categories/" + category.id} className={`inline-block p-4 border-b-2 rounded-t-lg
                              ${category.id === currentCategoryId ? "text-blue-600 border-b-2 border-blue-600 active dark:text-blue-500 dark:border-blue-500"
                                     : "border-transparent hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300"}`}>
                                 {category.text}
-                            </a>
+                            </Link>
                         </li>
                     );
                 })}

--- a/components/ThreadCategoryTab.tsx
+++ b/components/ThreadCategoryTab.tsx
@@ -1,0 +1,34 @@
+type Category = {
+    id: string
+    text: string
+}
+
+const categories = [
+    { id: "hot", text: "注目" },
+    { id: "chat", text: "雑談" },
+    { id: "social", text: "世の中" },
+    { id: "life", text: "生活" },
+    { id: "game", text: "アニメ・ゲーム" },
+    { id: "entertainment", text: "エンタメ" },
+    { id: "it", text: "テクノロジー" }
+]
+
+export default function ThreadCategoryTab({ currentCategoryId }: { currentCategoryId: string }) {
+    return (
+        <div className="text-sm font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700">
+            <ul className="flex flex-wrap -mb-px">
+                {categories.map((category: Category) => {
+                    return (
+                        <li key={category.id} className="mr-2">
+                            <a href="#" className={`inline-block p-4 border-b-2 rounded-t-lg
+                             ${category.id === currentCategoryId ? "text-blue-600 border-b-2 border-blue-600 active dark:text-blue-500 dark:border-blue-500"
+                                    : "border-transparent hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300"}`}>
+                                {category.text}
+                            </a>
+                        </li>
+                    );
+                })}
+            </ul>
+        </div>
+    )
+}

--- a/components/ThreadList.tsx
+++ b/components/ThreadList.tsx
@@ -10,7 +10,7 @@ type DummyData = {
 }
 
 async function fetchThreads(categoryId: string): Promise<DummyData[]> {
-    return await fetch("https://jsonplaceholder.typicode.com/posts")
+    return await fetch("https://jsonplaceholder.typicode.com/posts", { cache: "no-store" })
         .then((res) => res.json())
         .then(
             //ウエイト追加

--- a/model/Category.ts
+++ b/model/Category.ts
@@ -1,0 +1,16 @@
+export type Category = {
+    id: string
+    text: string
+};
+
+export const categories = [
+    { id: "hot", text: "注目" },
+    { id: "chat", text: "雑談" },
+    { id: "social", text: "世の中" },
+    { id: "life", text: "生活" },
+    { id: "game", text: "アニメ・ゲーム" },
+    { id: "entertainment", text: "エンタメ" },
+    { id: "it", text: "テクノロジー" }
+] as const;
+
+export const defaultCategory = categories[0];


### PR DESCRIPTION
## 概要
スレッドカテゴリを選択するタブUIを実装した

## やったこと説明
- https://github.com/u1fukui/bbs-next/pull/1/commits/0ce4c4538293488627d30b9ac8cd2463a9d254c7
  - タブUIを実装
  - Flowbite の Tab UI をベースにしている https://flowbite.com/docs/components/tabs/#tabs-with-underline
- https://github.com/u1fukui/bbs-next/pull/1/commits/51e37562580ec3d61788024139c7c9d79baf5bcc
  - 各タブ選択時はそれぞれデータ取得の必要があり、Server Component にした方がメリットが大きそうだったので、URL path   を分けるようにした
- https://github.com/u1fukui/bbs-next/pull/1/commits/727b8540f06c72eaabde64c30ce7162c3b970f68
  - URL直接入力で、 `/categories/xxx` と存在しない path を指定してきた場合に、404ページを返すようにした
- https://github.com/u1fukui/bbs-next/pull/1/commits/9fb1474ef816f242c1dae5b08367e05f9101c234
  - トップページに帰ってきやすいように、ヘッダロゴをクリックするとトップに戻れるようにした

## キャプチャ
### トップページ ( `/` )
![スクリーンショット 2023-07-27 22 42 02](https://github.com/u1fukui/bbs-next/assets/261403/f26a832e-d397-43af-9796-77ef1a8f3745)

### 適当なタブ選択時 ( `/categories/life` )
![スクリーンショット 2023-07-27 22 42 13](https://github.com/u1fukui/bbs-next/assets/261403/7b144297-4165-4660-8e92-95d235290e7c)

